### PR TITLE
Changes to facilitate multi-page rendering (also for KitchenAid)

### DIFF
--- a/cli/plugins/build/index.js
+++ b/cli/plugins/build/index.js
@@ -1,47 +1,73 @@
 'use strict';
 
+const fs = require('fs');
+
 /**
  * Build implements Joy commands for static S3 websites, swagger docs and docker images.
- * 
+ *
  */
 class Build {
-
   /**
    * @param {*} joy : Instance of a Joy class c/w config.json, env and helper functions
-   * 
+   *
    */
   constructor(joy) {
     const prog = joy.prog;
     prog
-      .command('build', 'Build a Joy project')
-      .argument('<subcommand>', 'subcommand [staticS3, swagger, docker]', ['staticS3', 'swagger', 'docker'])
+      .command('build_staticS3')
+      //.argument('[staticS3]', 'staticS3', ['staticS3'])
       .option('-s, --stage <stage>', 'Stage name', prog.STRING)
+      .option('-d, --data <data>', 'Data', prog.STRING)
+      .option('-i, --input <input>', 'Input file', prog.STRING)
       .action(async (args, options, logger) => {
-        logger.debug("arguments: %j", args);
-        logger.debug("options: %j", options);
-        const code = await this[args.subcommand].call(joy, options, logger);
+        logger.debug('arguments: %j', args);
+        logger.debug('options: %j', options);
+        const code = await this.staticS3.call(joy, options, logger);
+        return code;
+      });
+    prog.command('build_swagger').action(async (args, options, logger) => {
+      logger.debug('arguments: %j', args);
+      logger.debug('options: %j', options);
+      const code = await this.swagger.call(joy, options, logger);
+      return code;
+    });
+    prog
+      .command('build_docker')
+      .option('-i, --image <image>', 'Image name', prog.STRING)
+      .action(async (args, options, logger) => {
+        logger.debug('arguments: %j', args);
+        logger.debug('options: %j', options);
+        const code = await this.docker.call(joy, options, logger);
         return code;
       });
   }
 
-
   /**
    * @param {*} options : Additional CLI flags
-   * 
+   *
    */
   async staticS3(options) {
     // New instance of staticS3 initialized with joy.config and the chosen stage
     const s = require('./staticS3');
+    let payload;
+    if (options.input) {
+      payload = require(options.input);
+    }
+
     const statS3 = new s(this.config, options.stage);
-    await statS3.build();
+    await statS3.build(payload);
 
     // Return an exit code
     return 0;
   }
 
   // TODO: To be implemented
-  swagger() { }
-  docker() { }
+  swagger() {
+    console.error('not implemented yet');
+  }
+  docker() {
+    console.error('use joy docker for now');
+  }
 }
 
 module.exports = Build;

--- a/cli/plugins/build/staticS3.js
+++ b/cli/plugins/build/staticS3.js
@@ -14,6 +14,7 @@ const usemin = require('gulp-usemin');
 class StaticS3 {
   constructor(config, stage) {
     this.config = config;
+    config.src = './src';
     this.stage = stage;
     // Set build path
     switch (stage.toLowerCase()) {
@@ -42,20 +43,20 @@ class StaticS3 {
    * @returns
    * @memberof Tasks
    */
-  _compileViews() {
-    return new Promise((resolve, reject) => {
-      let pageData = {};
+  _compileViews(payload = {}) {
+    payload.renderer(ejs.__EJS__.renderFile);
 
+    return new Promise((resolve, reject) => {
       // See https://github.com/mde/ejs for options
       gulp
-        .src(`${this.config.src}/views/**/*.html`, pageData)
+        .src(`${this.config.src}/views/**/*.html`)
 
         .on('error', (e) => {
           console.error('e', e);
           reject(e);
         })
         .pipe(debug())
-        .pipe(ejs({}))
+        .pipe(ejs({ payload }))
 
         .pipe(rename({ extname: '.html' }))
         .pipe(gulp.dest(this.buildPath))
@@ -64,10 +65,10 @@ class StaticS3 {
     });
   }
 
-  async build() {
+  async build(payload) {
     await del([`${this.buildPath}**/*`]);
 
-    await this._compileViews().catch((e) => {
+    await this._compileViews(payload).catch((e) => {
       console.error('caught1', e);
     });
 


### PR DESCRIPTION
- Separated build params into three build commands including `build_staticS3`
- Modified _compileViews() to accept data and code, in the form of a required module, to implement site-specific rendering.