### PR TITLE
Added vendor folder to list of folders to copy to target

### DIFF
--- a/cli/services/StaticGenerator/StaticGenerator.js
+++ b/cli/services/StaticGenerator/StaticGenerator.js
@@ -164,6 +164,10 @@ class StaticGenerator {
       {
         glob: [`${this.config.src}/manifest.json`],
         dest: '/'
+      },
+      {
+        glob: [`${this.config.src}/vendor/**/*.*`],
+        dest: '/vendor/'
       }
     ]).catch((e) => {
       console.error('caught', e);


### PR DESCRIPTION
Joy was unaware of the vendor folder convention and was not copying it during the static build process.