### PR TITLE
Added support for an S3 backed private Docker registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-# joy v0.3.3
+# Joy CLI
 
 The Jake and trOY devops-y utility
 
-- [joy v0.3.3](#joy-v033)
-
+- [Joy CLI](#joy-cli)
   - [Installation](#installation)
   - [Built With](#built-with)
   - [Tips and Tricks](#tips-and-tricks)

--- a/README.md
+++ b/README.md
@@ -2,11 +2,25 @@
 
 The Jake and trOY devops-y utility
 
+- [joy v0.3.3](#joy-v033)
+
+  - [Installation](#installation)
+  - [Built With](#built-with)
+  - [Tips and Tricks](#tips-and-tricks)
+    - [Required Runtime Dependencies](#required-runtime-dependencies)
+    - [Required Development Dependencies](#required-development-dependencies)
+    - [Configure a new Joy project](#configure-a-new-joy-project)
+    - [Current Joy Commands](#current-joy-commands)
+    - [Notes for .joy/config.json](#notes-for-joyconfigjson)
+    - [Debugging from Visual Studio Code](#debugging-from-visual-studio-code)
+  - [Change Log](#change-log)
+
 ## Installation
 
 1. Git clone the project
 2. Checkout master
 3. Create an alias in bash to cli/joy.js
+4. Add a new AWS profile for [registry.joy] in ~/.aws/credentials. See @troy for values until we have a shared secrets process.
 
 ## Built With
 
@@ -41,7 +55,6 @@ The following is a list of the technologies used to develop and manage this proj
 - Git
 - A code editor
 
-
 ### Configure a new Joy project
 
 Instructions here to explain how to use `joy init` and what to change in the config.env file.
@@ -53,9 +66,14 @@ SWAGGER_FILE_URI=http://localhost:10010/swagger
 SLACK_INCOMING_WEBHOOK_URL https://hooks.slack.com/services/T7KSWL4E9/BGL0HSVB2/************************
 ```
 
-### Joy Commands
+### Current Joy Commands
 
-Coming soon...
+| Joy   | Subcommand | Subcommand | Subcommand | Description                                                                                                                                             | Flags            |
+| ----- | ---------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| start | docker     | registry   |            | Starts the private Docker registry on http://localhost:5000. This command requires a properly configured AWS credentials profile called [registry.joy]. |                  |
+| stop  | docker     | registry   |            | Stops the private Docker registry                                                                                                                       |                  |
+| build |            |            |            |                                                                                                                                                         |                  |
+| build | static     |            |            | Compiles the static site into build/dev, build/stage or build/prod depending upon the stage flag                                                        | -s --stage stage |
 
 ### Notes for .joy/config.json
 
@@ -65,7 +83,7 @@ Coming soon...
 
 Create an appropriate configuration in ./vscode/launch.json
 
-``` javascript
+```javascript
 {
   "version": "0.2.0",
   "configurations": [{
@@ -85,6 +103,14 @@ Create an appropriate configuration in ./vscode/launch.json
 ```
 
 ## Change Log
+
+v1.1.0 **Joy Private Docker Registry** (2019-10-02)
+
+Added support for an S3 backed private Docker registry
+
+- Note that since Joy defines that we store per-client AWS credentials in ~/.aws/credentials, this tool is now accesses and reads that file. There is no writing at this time and read credentials are stored in memory only.
+- This release also sees some cleanup of joy.js where routes have now been moved out to a separate routes/index.js file.
+- Also added a new commands summary table in the section above. Updates to this table should be synchronized with future feature releases and the changelog for enhanced communication of changes.
 
 v1.0.0 **Breaking Refactor** (2019-09-13)
 

--- a/cli/controllers/index.js
+++ b/cli/controllers/index.js
@@ -89,6 +89,55 @@ class Controllers {
     }
     console.log('not yet implemented');
   }
+
+
+
+  /**
+   *
+   * Creates and starts a new Joy private Docker registry container. If the container already exists and is stopped, it is restarted.
+   * @param {object} options An object containing the route, parsed flags and route definition
+   * @returns An exit code as an integer
+   * @memberof Controllers
+   */
+  async startDockerRegistry(options) {
+    // TODO: Add support to invoke for spawn AND exec. Exec will allow us to $(docker ps -a | grep registry.joy) to check if container is already running
+
+    let retVal = await this.invoke('docker', [
+      'run', '-d',
+      '-p', '5000:5000',
+      '--name', 'registry.joy',
+      '-e', 'REGISTRY_STORAGE=s3',
+      '-e', 'REGISTRY_STORAGE_S3_REGION=ca-central-1',
+      '-e', 'REGISTRY_STORAGE_S3_BUCKET=registry.joy',
+      '-e', `REGISTRY_STORAGE_S3_ACCESSKEY=${this.config.awsProfiles.kitchenaid.aws_access_key_id}`,
+      '-e', `REGISTRY_STORAGE_S3_SECRETKEY=${this.config.awsProfiles.kitchenaid.aws_secret_access_key}`,
+      'registry:2'
+    ]);
+
+    if (retVal !== 0) {
+      console.log('Ignore the previous message, spawning now (this to be cleaned up in a future release).')
+
+      retVal = await this.invoke('docker', [
+        'start', 'registry.joy'
+      ])
+    }
+
+    return retVal;
+  }
+
+  /**
+   *
+   * Stops the Joy private Docker registry if it is running
+   * @param {object} options An object containing the route, parsed flags and route definition
+   * @returns An exit code as an integer
+   * @memberof Controllers
+   */
+  async stopDockerRegistry(options) {
+    return await this.invoke('docker', [
+      'stop', 'registry.joy'
+    ]);
+  }
+
 }
 
 const controllers = new Controllers();
@@ -99,3 +148,5 @@ module.exports.build = controllers.build;
 module.exports.buildStatic = controllers.buildStatic;
 module.exports.buildSwagger = controllers.buildSwagger;
 module.exports.buildDocker = controllers.buildDocker;
+module.exports.startDockerRegistry = controllers.startDockerRegistry;
+module.exports.stopDockerRegistry = controllers.stopDockerRegistry;

--- a/cli/controllers/index.js
+++ b/cli/controllers/index.js
@@ -109,8 +109,8 @@ class Controllers {
       '-e', 'REGISTRY_STORAGE=s3',
       '-e', 'REGISTRY_STORAGE_S3_REGION=ca-central-1',
       '-e', 'REGISTRY_STORAGE_S3_BUCKET=registry.joy',
-      '-e', `REGISTRY_STORAGE_S3_ACCESSKEY=${this.config.awsProfiles.kitchenaid.aws_access_key_id}`,
-      '-e', `REGISTRY_STORAGE_S3_SECRETKEY=${this.config.awsProfiles.kitchenaid.aws_secret_access_key}`,
+      '-e', `REGISTRY_STORAGE_S3_ACCESSKEY=${this.config.awsProfiles.registry.joy.aws_access_key_id}`,
+      '-e', `REGISTRY_STORAGE_S3_SECRETKEY=${this.config.awsProfiles.registry.joy.aws_secret_access_key}`,
       'registry:2'
     ]);
 

--- a/cli/routes.js
+++ b/cli/routes.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const controllers = require('./controllers');
+
+module.exports = function (joy) {
+  joy.use('help',
+    [], controllers.help);
+
+  joy.use('build',
+    [], controllers.build);
+
+  joy.use('build/static',
+    [{
+      name: 'stage',
+      flag: { short: '-s', long: '--stage' },
+      help: 'The stage to build for (e.g. dev, stage, prod)'
+    },
+    {
+      name: 'watch',
+      flag: { short: '-w', long: '--watch' },
+      help: 'Watch for changes in /src folder'
+    }], controllers.buildStatic);
+
+  joy.use('build/swagger',
+    [{
+      name: 'watch',
+      flag: { short: '-w', long: '--watch' },
+      help: 'Watch for changes in swagger folder'
+    }], controllers.buildSwagger);
+
+  joy.use('build/docker',
+    [{
+      name: 'name',
+      flag: { short: '-n', long: '--name' },
+      help: 'Docker file prefix (e.g. www, db, etc.'
+    }], controllers.buildDocker);
+
+  joy.use('start/docker/registry',
+    [{
+    }],
+    controllers.startDockerRegistry);
+
+  joy.use('stop/docker/registry', [{
+  }], controllers.stopDockerRegistry);
+
+  joy.use('start/docker/container',
+    [{
+      name: 'name',
+      flag: { short: '-n', long: '--name' },
+      help: 'Name of docker image from .joy/docker to start as a container'
+    }], controllers.startDockerContainer);
+
+}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@tforster/joy",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tforster/joy",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "The Jake and trOY devopsy utility",
   "dependencies": {
     "aws-sdk": "^2.517.0",
@@ -17,6 +17,7 @@
     "gulp-rename": "^1.4.0",
     "gulp-rev": "^9.0.0",
     "gulp-usemin": "^0.3.29",
+    "ini": "^1.3.5",
     "semver": "^5.6.0",
     "through2": "^3.0.1",
     "vinyl-fs": "^3.0.3"


### PR DESCRIPTION
FYI: My-bad. Branch name should have been docker-registry. I have been inadvertently swapping repository and registry. Correct Docker terminology is "registry". Catching myself going forward.

- Note that since Joy defines that we store per-client AWS credentials in ~/.aws/credentials, this tool now accesses and reads that file. There is no writing at this time and read credentials are stored in memory only.
- This release also sees some cleanup of joy.js where routes have now been moved out to a separate routes/index.js file.
- Also added a new commands summary table in the section above. Updates to this table should be synchronized with future feature releases and the changelog for enhanced communication of changes.